### PR TITLE
Support for usergroup app permission for templates

### DIFF
--- a/docs/resources/user_group.md
+++ b/docs/resources/user_group.md
@@ -73,6 +73,10 @@ resource "harness_user_group" "example" {
         actions = ["UPDATE", "DELETE"]
       }
 
+      template {
+        actions = ["CREATE", "READ", "UPDATE", "DELETE"]
+      }
+
       workflow {
         actions = ["UPDATE", "DELETE"]
         filters = ["NON_PRODUCTION_WORKFLOWS", ]
@@ -151,6 +155,7 @@ Optional:
 - **pipeline** (Block Set) Permission configuration to perform actions against pipelines. (see [below for nested schema](#nestedblock--permissions--app_permissions--pipeline))
 - **provisioner** (Block Set) Permission configuration to perform actions against provisioners. (see [below for nested schema](#nestedblock--permissions--app_permissions--provisioner))
 - **service** (Block Set) Permission configuration to perform actions against services. (see [below for nested schema](#nestedblock--permissions--app_permissions--service))
+- **template** (Block Set) Permission configuration to perform actions against templates. (see [below for nested schema](#nestedblock--permissions--app_permissions--template))
 - **workflow** (Block Set) Permission configuration to perform actions against workflows. (see [below for nested schema](#nestedblock--permissions--app_permissions--workflow))
 
 <a id="nestedblock--permissions--app_permissions--all"></a>
@@ -231,6 +236,19 @@ Optional:
 
 - **app_ids** (Set of String) The application IDs to which the permission applies. Leave empty to apply to all applications.
 - **service_ids** (Set of String) The service IDs to which the permission applies. Leave empty to apply to all services.
+
+
+<a id="nestedblock--permissions--app_permissions--template"></a>
+### Nested Schema for `permissions.app_permissions.template`
+
+Required:
+
+- **actions** (Set of String) The actions allowed to be performed. Valid options are CREATE, READ, UPDATE, DELETE
+
+Optional:
+
+- **app_ids** (Set of String) The application IDs to which the permission applies. Leave empty to apply to all applications.
+- **template_ids** (Set of String) The template IDs to which the permission applies. Leave empty to apply to all environments.
 
 
 <a id="nestedblock--permissions--app_permissions--workflow"></a>

--- a/examples/resources/harness_user_group/resource.tf
+++ b/examples/resources/harness_user_group/resource.tf
@@ -58,6 +58,10 @@ resource "harness_user_group" "example" {
         actions = ["UPDATE", "DELETE"]
       }
 
+      template {
+        actions = ["CREATE", "READ", "UPDATE", "DELETE"]
+      }
+
       workflow {
         actions = ["UPDATE", "DELETE"]
         filters = ["NON_PRODUCTION_WORKFLOWS", ]

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go v1.37.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/google/uuid v1.2.0 // indirect
-	github.com/harness-io/harness-go-sdk v0.0.10
+	github.com/harness-io/harness-go-sdk v0.0.11
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-hclog v0.16.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,8 @@ github.com/harness-io/harness-go-sdk v0.0.9 h1:W+KS8+ODPwYeSY6f01KeCfYJ9C3Egge+N
 github.com/harness-io/harness-go-sdk v0.0.9/go.mod h1:/5oCswBe0pg/6GAuviqJErMxGgQWx+/OOD7UQ74d1FY=
 github.com/harness-io/harness-go-sdk v0.0.10 h1:QDUw5LFJP9MO6Gr6NIPWbD0rGWX+4qVlr7mCGXCiiU0=
 github.com/harness-io/harness-go-sdk v0.0.10/go.mod h1:/5oCswBe0pg/6GAuviqJErMxGgQWx+/OOD7UQ74d1FY=
+github.com/harness-io/harness-go-sdk v0.0.11 h1:qfIYLlPgfAzvQJx/+ZbjFneuQfN0hzfQuVBLph976AA=
+github.com/harness-io/harness-go-sdk v0.0.11/go.mod h1:/5oCswBe0pg/6GAuviqJErMxGgQWx+/OOD7UQ74d1FY=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/internal/provider/resource_cloudprovider_tanzu.go
+++ b/internal/provider/resource_cloudprovider_tanzu.go
@@ -138,30 +138,3 @@ func resourceCloudProviderTanzuCreateOrUpdate(ctx context.Context, d *schema.Res
 
 	return readCloudProviderTanzu(c, d, cp)
 }
-
-func resourceCloudProviderTanzuUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*api.Client)
-
-	cp := cac.NewEntity(cac.ObjectTypes.AzureCloudProvider).(*cac.PcfCloudProvider)
-	cp.Name = d.Get("name").(string)
-	cp.EndpointUrl = d.Get("endpoint").(string)
-	cp.SkipValidation = d.Get("skip_validation").(bool)
-	cp.Username = d.Get("username").(string)
-
-	if attr := d.Get("username_secret_name").(string); attr != "" {
-		cp.UsernameSecretId = &cac.SecretRef{
-			Name: attr,
-		}
-	}
-
-	cp.Password = &cac.SecretRef{
-		Name: d.Get("password_secret_name").(string),
-	}
-
-	_, err := c.ConfigAsCode().UpsertPcfCloudProvider(cp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	return nil
-}

--- a/internal/provider/resource_git_connector_test.go
+++ b/internal/provider/resource_git_connector_test.go
@@ -249,29 +249,6 @@ func testAccResourceGitConnector(name string, generateWebhook bool, withCommitDe
 `, name, generateWebhook, commitDetails, delegateSelectors)
 }
 
-func testAccResourceGitConnector_invalid_urltype(name string) string {
-	return fmt.Sprintf(`
-		data "harness_secret_manager" "test" {
-			default = true 
-		}
-
-		resource "harness_encrypted_text" "test" {
-			name              = "%[1]s"
-			value 					  = "foo"
-			secret_manager_id = data.harness_secret_manager.test.id
-		}
-
-		resource "harness_git_connector" "test" {
-			name = "%[1]s"
-			url = "https://github.com/micahlmartin/harness-demo"
-			branch = "master"
-			password_secret_id = harness_encrypted_text.test.id
-			url_type = "badvalue"
-			username = "someuser"
-		}	
-`, name)
-}
-
 // func testAccResourceEncryptedText_UsageScopes(name string) string {
 // 	// nonprod :=
 // 	return fmt.Sprintf(`

--- a/internal/provider/resource_infrastructure_definition_test.go
+++ b/internal/provider/resource_infrastructure_definition_test.go
@@ -357,26 +357,6 @@ func testAccInfraDefK8s(name string) string {
 `, name)
 }
 
-func testAccInfraDefAws(name string) string {
-	return fmt.Sprintf(`
-		resource "harness_cloudprovider_aws" "test" {
-			name = "%[1]s"
-			// delegate_selector = "aws"
-
-		}
-
-		resource "harness_application" "test" {
-			name = "%[1]s"
-		}
-
-		resource "harness_environment" "test" {
-			name = "%[1]s"
-			app_id = harness_application.test.id
-			type = "NON_PROD"
-		}
-`, name)
-}
-
 func testAccResourceInfraDefEnvironment(name string) string {
 	return fmt.Sprintf(`
 		resource "harness_application" "test" {

--- a/internal/provider/resource_service_aws_codedeploy.go
+++ b/internal/provider/resource_service_aws_codedeploy.go
@@ -93,30 +93,3 @@ func resourceAWSCodeDeployServiceCreateOrUpdate(ctx context.Context, d *schema.R
 
 	return readServiceCodeDeploy(d, newSvc)
 }
-
-func resourceAWSCodeDeployServiceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*api.Client)
-
-	// Setup the object to create
-	svcInput := &cac.Service{
-		Name:           d.Get("name").(string),
-		ArtifactType:   cac.ArtifactTypes.AWSCodeDeploy,
-		DeploymentType: cac.DeploymentTypes.AWSCodeDeploy,
-		ApplicationId:  d.Get("app_id").(string),
-		Description:    d.Get("description").(string),
-	}
-
-	if vars := d.Get("variable"); vars != nil {
-		svcInput.ConfigVariables = expandServiceVariables(vars.(*schema.Set).List())
-	}
-
-	// Create Service
-	newSvc, err := c.ConfigAsCode().UpsertService(svcInput)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	d.SetId(newSvc.Id)
-
-	return nil
-}

--- a/internal/provider/resource_service_aws_lambda.go
+++ b/internal/provider/resource_service_aws_lambda.go
@@ -93,30 +93,3 @@ func resourceAWSLambdaServiceCreateOrUpdate(ctx context.Context, d *schema.Resou
 
 	return readServiceAwsLambda(d, newSvc)
 }
-
-func resourceAWSLambdaServiceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*api.Client)
-
-	// Setup the object to create
-	svcInput := &cac.Service{
-		Name:           d.Get("name").(string),
-		ArtifactType:   cac.ArtifactTypes.AWSLambda,
-		DeploymentType: cac.DeploymentTypes.AWSLambda,
-		ApplicationId:  d.Get("app_id").(string),
-		Description:    d.Get("description").(string),
-	}
-
-	if vars := d.Get("variable"); vars != nil {
-		svcInput.ConfigVariables = expandServiceVariables(vars.(*schema.Set).List())
-	}
-
-	// Create Service
-	newSvc, err := c.ConfigAsCode().UpsertService(svcInput)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	d.SetId(newSvc.Id)
-
-	return nil
-}

--- a/internal/provider/resource_service_winrm.go
+++ b/internal/provider/resource_service_winrm.go
@@ -105,30 +105,3 @@ func resourceWinRMServiceCreateOrUpdate(ctx context.Context, d *schema.ResourceD
 
 	return readServiceWinRM(d, newSvc)
 }
-
-func resourceWinRMServiceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*api.Client)
-
-	// Setup the object to create
-	svcInput := &cac.Service{
-		Name:           d.Get("name").(string),
-		ArtifactType:   cac.ArtifactType(d.Get("artifact_type").(string)),
-		DeploymentType: cac.DeploymentTypes.WinRM,
-		ApplicationId:  d.Get("app_id").(string),
-		Description:    d.Get("description").(string),
-	}
-
-	if vars := d.Get("variable"); vars != nil {
-		svcInput.ConfigVariables = expandServiceVariables(vars.(*schema.Set).List())
-	}
-
-	// Create Service
-	newSvc, err := c.ConfigAsCode().UpsertService(svcInput)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	d.SetId(newSvc.Id)
-
-	return nil
-}

--- a/internal/provider/resource_user_group_test.go
+++ b/internal/provider/resource_user_group_test.go
@@ -64,6 +64,11 @@ func TestAccResourceUserGroup_SAML(t *testing.T) {
 					testAccUserGroupCreation(t, resourceName, expectedName),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -85,6 +90,11 @@ func TestAccResourceUserGroup_NotificationsSettings(t *testing.T) {
 					testAccUserGroupCreation(t, resourceName, expectedName),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -105,6 +115,11 @@ func TestAccResourceUserGroup_AccountPermissions(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", expectedName),
 					testAccUserGroupCreation(t, resourceName, expectedName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -161,6 +176,11 @@ func TestAccResourceUserGroup_AppPermissions(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", expectedName),
 					testAccUserGroupCreation(t, resourceName, expectedName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -254,6 +274,10 @@ func testAccResourceUserGroupAppPermissions(name string) string {
 
 					service {
 						actions = ["UPDATE", "DELETE"]
+					}
+					
+					template {
+						actions = ["CREATE", "READ", "UPDATE", "DELETE"]
 					}
 
 					workflow {


### PR DESCRIPTION
For the resource "harness_user_group"`, a new section has been added to support granular permissions for templates.

```
template {
  template_ids = ["abc123"]
  app_ids = ["app123"]
  actions = ["CREATE", "READ", "UPDATE", "DELETE"]
}
```