### PR TITLE
Fix issues related to renaming config-as-code items

### DIFF
--- a/docs/resources/cloudprovider_aws.md
+++ b/docs/resources/cloudprovider_aws.md
@@ -3,12 +3,12 @@
 page_title: "harness_cloudprovider_aws Resource - terraform-provider-harness"
 subcategory: ""
 description: |-
-  Resource for creating an AWS cloud provider
+  Resource for creating an AWS cloud provider. This object uses the config-as-code API's. When updating the name or path of this resource you should typically also set the create_before_destroy = true lifecycle setting.
 ---
 
 # harness_cloudprovider_aws (Resource)
 
-Resource for creating an AWS cloud provider
+Resource for creating an AWS cloud provider. This object uses the config-as-code API's. When updating the `name` or `path` of this resource you should typically also set the `create_before_destroy = true` lifecycle setting.
 
 ## Example Usage
 

--- a/docs/resources/cloudprovider_azure.md
+++ b/docs/resources/cloudprovider_azure.md
@@ -3,12 +3,12 @@
 page_title: "harness_cloudprovider_azure Resource - terraform-provider-harness"
 subcategory: ""
 description: |-
-  Resource for creating an Azure cloud provider
+  Resource for creating an Azure cloud provider. This object uses the config-as-code API's. When updating the name or path of this resource you should typically also set the create_before_destroy = true lifecycle setting.
 ---
 
 # harness_cloudprovider_azure (Resource)
 
-Resource for creating an Azure cloud provider
+Resource for creating an Azure cloud provider. This object uses the config-as-code API's. When updating the `name` or `path` of this resource you should typically also set the `create_before_destroy = true` lifecycle setting.
 
 ## Example Usage
 

--- a/docs/resources/cloudprovider_datacenter.md
+++ b/docs/resources/cloudprovider_datacenter.md
@@ -3,12 +3,12 @@
 page_title: "harness_cloudprovider_datacenter Resource - terraform-provider-harness"
 subcategory: ""
 description: |-
-  Resource for creating a physical data center cloud provider
+  Resource for creating a physical data center cloud provider. This object uses the config-as-code API's. When updating the name or path of this resource you should typically also set the create_before_destroy = true lifecycle setting.
 ---
 
 # harness_cloudprovider_datacenter (Resource)
 
-Resource for creating a physical data center cloud provider
+Resource for creating a physical data center cloud provider. This object uses the config-as-code API's. When updating the `name` or `path` of this resource you should typically also set the `create_before_destroy = true` lifecycle setting.
 
 ## Example Usage
 

--- a/docs/resources/cloudprovider_gcp.md
+++ b/docs/resources/cloudprovider_gcp.md
@@ -3,12 +3,12 @@
 page_title: "harness_cloudprovider_gcp Resource - terraform-provider-harness"
 subcategory: ""
 description: |-
-  Resource for creating a GCP cloud provider
+  Resource for creating a GCP cloud provider. This object uses the config-as-code API's. When updating the name or path of this resource you should typically also set the create_before_destroy = true lifecycle setting.
 ---
 
 # harness_cloudprovider_gcp (Resource)
 
-Resource for creating a GCP cloud provider
+Resource for creating a GCP cloud provider. This object uses the config-as-code API's. When updating the `name` or `path` of this resource you should typically also set the `create_before_destroy = true` lifecycle setting.
 
 
 

--- a/docs/resources/cloudprovider_kubernetes.md
+++ b/docs/resources/cloudprovider_kubernetes.md
@@ -3,12 +3,12 @@
 page_title: "harness_cloudprovider_kubernetes Resource - terraform-provider-harness"
 subcategory: ""
 description: |-
-  Resource for creating a Kubernetes cloud provider
+  Resource for creating a Kubernetes cloud provider. This object uses the config-as-code API's. When updating the name or path of this resource you should typically also set the create_before_destroy = true lifecycle setting.
 ---
 
 # harness_cloudprovider_kubernetes (Resource)
 
-Resource for creating a Kubernetes cloud provider
+Resource for creating a Kubernetes cloud provider. This object uses the config-as-code API's. When updating the `name` or `path` of this resource you should typically also set the `create_before_destroy = true` lifecycle setting.
 
 ## Example Usage
 
@@ -39,6 +39,10 @@ resource "harness_cloudprovider_kubernetes" "example" {
       username_secret_name = harness_encrypted_text.username.name
       password_secret_name = harness_encrypted_text.password.name
     }
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 ```

--- a/docs/resources/cloudprovider_spot.md
+++ b/docs/resources/cloudprovider_spot.md
@@ -3,12 +3,12 @@
 page_title: "harness_cloudprovider_spot Resource - terraform-provider-harness"
 subcategory: ""
 description: |-
-  Resource for creating a Spot cloud provider
+  Resource for creating a Spot cloud provider. This object uses the config-as-code API's. When updating the name or path of this resource you should typically also set the create_before_destroy = true lifecycle setting.
 ---
 
 # harness_cloudprovider_spot (Resource)
 
-Resource for creating a Spot cloud provider
+Resource for creating a Spot cloud provider. This object uses the config-as-code API's. When updating the `name` or `path` of this resource you should typically also set the `create_before_destroy = true` lifecycle setting.
 
 ## Example Usage
 

--- a/docs/resources/cloudprovider_tanzu.md
+++ b/docs/resources/cloudprovider_tanzu.md
@@ -3,12 +3,12 @@
 page_title: "harness_cloudprovider_tanzu Resource - terraform-provider-harness"
 subcategory: ""
 description: |-
-  Resource for creating a Tanzu cloud provider
+  Resource for creating a Tanzu cloud provider. This object uses the config-as-code API's. When updating the name or path of this resource you should typically also set the create_before_destroy = true lifecycle setting.
 ---
 
 # harness_cloudprovider_tanzu (Resource)
 
-Resource for creating a Tanzu cloud provider
+Resource for creating a Tanzu cloud provider. This object uses the config-as-code API's. When updating the `name` or `path` of this resource you should typically also set the `create_before_destroy = true` lifecycle setting.
 
 ## Example Usage
 

--- a/docs/resources/infrastructure_definition.md
+++ b/docs/resources/infrastructure_definition.md
@@ -3,12 +3,12 @@
 page_title: "harness_infrastructure_definition Resource - terraform-provider-harness"
 subcategory: ""
 description: |-
-  Resource for creating am infrastructure definition
+  Resource for creating am infrastructure definition. This object uses the config-as-code API's. When updating the name or path of this resource you should typically also set the create_before_destroy = true lifecycle setting.
 ---
 
 # harness_infrastructure_definition (Resource)
 
-Resource for creating am infrastructure definition
+Resource for creating am infrastructure definition. This object uses the config-as-code API's. When updating the `name` or `path` of this resource you should typically also set the `create_before_destroy = true` lifecycle setting.
 
 ## Example Usage
 

--- a/docs/resources/service_ami.md
+++ b/docs/resources/service_ami.md
@@ -3,12 +3,12 @@
 page_title: "harness_service_ami Resource - terraform-provider-harness"
 subcategory: ""
 description: |-
-  Resource for creating an AMI service
+  Resource for creating an AMI service. This object uses the config-as-code API's. When updating the name or path of this resource you should typically also set the create_before_destroy = true lifecycle setting.
 ---
 
 # harness_service_ami (Resource)
 
-Resource for creating an AMI service
+Resource for creating an AMI service. This object uses the config-as-code API's. When updating the `name` or `path` of this resource you should typically also set the `create_before_destroy = true` lifecycle setting.
 
 ## Example Usage
 

--- a/docs/resources/service_aws_codedeploy.md
+++ b/docs/resources/service_aws_codedeploy.md
@@ -3,12 +3,12 @@
 page_title: "harness_service_aws_codedeploy Resource - terraform-provider-harness"
 subcategory: ""
 description: |-
-  Resource for creating an AWS CodeDeploy service
+  Resource for creating an AWS CodeDeploy service. This object uses the config-as-code API's. When updating the name or path of this resource you should typically also set the create_before_destroy = true lifecycle setting.
 ---
 
 # harness_service_aws_codedeploy (Resource)
 
-Resource for creating an AWS CodeDeploy service
+Resource for creating an AWS CodeDeploy service. This object uses the config-as-code API's. When updating the `name` or `path` of this resource you should typically also set the `create_before_destroy = true` lifecycle setting.
 
 ## Example Usage
 

--- a/docs/resources/service_aws_lambda.md
+++ b/docs/resources/service_aws_lambda.md
@@ -3,12 +3,12 @@
 page_title: "harness_service_aws_lambda Resource - terraform-provider-harness"
 subcategory: ""
 description: |-
-  Resource for creating an AWS Lambda service
+  Resource for creating an AWS Lambda service. This object uses the config-as-code API's. When updating the name or path of this resource you should typically also set the create_before_destroy = true lifecycle setting.
 ---
 
 # harness_service_aws_lambda (Resource)
 
-Resource for creating an AWS Lambda service
+Resource for creating an AWS Lambda service. This object uses the config-as-code API's. When updating the `name` or `path` of this resource you should typically also set the `create_before_destroy = true` lifecycle setting.
 
 ## Example Usage
 

--- a/docs/resources/service_ecs.md
+++ b/docs/resources/service_ecs.md
@@ -3,12 +3,12 @@
 page_title: "harness_service_ecs Resource - terraform-provider-harness"
 subcategory: ""
 description: |-
-  Resource for creating an AWS ECS service
+  Resource for creating an AWS ECS service. This object uses the config-as-code API's. When updating the name or path of this resource you should typically also set the create_before_destroy = true lifecycle setting.
 ---
 
 # harness_service_ecs (Resource)
 
-Resource for creating an AWS ECS service
+Resource for creating an AWS ECS service. This object uses the config-as-code API's. When updating the `name` or `path` of this resource you should typically also set the `create_before_destroy = true` lifecycle setting.
 
 ## Example Usage
 

--- a/docs/resources/service_helm.md
+++ b/docs/resources/service_helm.md
@@ -3,12 +3,12 @@
 page_title: "harness_service_helm Resource - terraform-provider-harness"
 subcategory: ""
 description: |-
-  Resource for creating a Kubernetes Helm service
+  Resource for creating a Kubernetes Helm service. This object uses the config-as-code API's. When updating the name or path of this resource you should typically also set the create_before_destroy = true lifecycle setting.
 ---
 
 # harness_service_helm (Resource)
 
-Resource for creating a Kubernetes Helm service
+Resource for creating a Kubernetes Helm service. This object uses the config-as-code API's. When updating the `name` or `path` of this resource you should typically also set the `create_before_destroy = true` lifecycle setting.
 
 ## Example Usage
 

--- a/docs/resources/service_kubernetes.md
+++ b/docs/resources/service_kubernetes.md
@@ -3,12 +3,12 @@
 page_title: "harness_service_kubernetes Resource - terraform-provider-harness"
 subcategory: ""
 description: |-
-  Resource for creating a Kubernetes service
+  Resource for creating a Kubernetes service. This object uses the config-as-code API's. When updating the name or path of this resource you should typically also set the create_before_destroy = true lifecycle setting.
 ---
 
 # harness_service_kubernetes (Resource)
 
-Resource for creating a Kubernetes service
+Resource for creating a Kubernetes service. This object uses the config-as-code API's. When updating the `name` or `path` of this resource you should typically also set the `create_before_destroy = true` lifecycle setting.
 
 ## Example Usage
 

--- a/docs/resources/service_ssh.md
+++ b/docs/resources/service_ssh.md
@@ -3,12 +3,12 @@
 page_title: "harness_service_ssh Resource - terraform-provider-harness"
 subcategory: ""
 description: |-
-  Resource for creating an SSH service
+  Resource for creating an SSH service. This object uses the config-as-code API's. When updating the name or path of this resource you should typically also set the create_before_destroy = true lifecycle setting.
 ---
 
 # harness_service_ssh (Resource)
 
-Resource for creating an SSH service
+Resource for creating an SSH service. This object uses the config-as-code API's. When updating the `name` or `path` of this resource you should typically also set the `create_before_destroy = true` lifecycle setting.
 
 ## Example Usage
 

--- a/docs/resources/service_tanzu.md
+++ b/docs/resources/service_tanzu.md
@@ -3,12 +3,12 @@
 page_title: "harness_service_tanzu Resource - terraform-provider-harness"
 subcategory: ""
 description: |-
-  Resource for creating a Tanzu (PCF) service
+  Resource for creating a Tanzu (PCF) service. This object uses the config-as-code API's. When updating the name or path of this resource you should typically also set the create_before_destroy = true lifecycle setting.
 ---
 
 # harness_service_tanzu (Resource)
 
-Resource for creating a Tanzu (PCF) service
+Resource for creating a Tanzu (PCF) service. This object uses the config-as-code API's. When updating the `name` or `path` of this resource you should typically also set the `create_before_destroy = true` lifecycle setting.
 
 ## Example Usage
 

--- a/docs/resources/service_winrm.md
+++ b/docs/resources/service_winrm.md
@@ -3,12 +3,12 @@
 page_title: "harness_service_winrm Resource - terraform-provider-harness"
 subcategory: ""
 description: |-
-  Resource for creating an WinRM service
+  Resource for creating an WinRM service. This object uses the config-as-code API's. When updating the name or path of this resource you should typically also set the create_before_destroy = true lifecycle setting.
 ---
 
 # harness_service_winrm (Resource)
 
-Resource for creating an WinRM service
+Resource for creating an WinRM service. This object uses the config-as-code API's. When updating the `name` or `path` of this resource you should typically also set the `create_before_destroy = true` lifecycle setting.
 
 ## Example Usage
 

--- a/docs/resources/yaml_config.md
+++ b/docs/resources/yaml_config.md
@@ -3,12 +3,12 @@
 page_title: "harness_yaml_config Resource - terraform-provider-harness"
 subcategory: ""
 description: |-
-  Resource for creating a raw YAML configuration in Harness. Note: This works for all objects EXCEPT application objects.
+  Resource for creating a raw YAML configuration in Harness. Note: This works for all objects EXCEPT application objects. This object uses the config-as-code API's. When updating the name or path of this resource you should typically also set the create_before_destroy = true lifecycle setting.
 ---
 
 # harness_yaml_config (Resource)
 
-Resource for creating a raw YAML configuration in Harness. Note: This works for all objects EXCEPT application objects.
+Resource for creating a raw YAML configuration in Harness. Note: This works for all objects EXCEPT application objects. This object uses the config-as-code API's. When updating the `name` or `path` of this resource you should typically also set the `create_before_destroy = true` lifecycle setting.
 
 ## Example Usage
 

--- a/examples/resources/harness_cloudprovider_kubernetes/resource.tf
+++ b/examples/resources/harness_cloudprovider_kubernetes/resource.tf
@@ -25,4 +25,8 @@ resource "harness_cloudprovider_kubernetes" "example" {
       password_secret_name = harness_encrypted_text.password.name
     }
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go v1.37.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/google/uuid v1.2.0 // indirect
-	github.com/harness-io/harness-go-sdk v0.0.13
+	github.com/harness-io/harness-go-sdk v0.0.14
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-hclog v0.16.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/harness-io/harness-go-sdk v0.0.12 h1:EIy3PNsiSCrykctPE3PzNo7IZh5ubyoM
 github.com/harness-io/harness-go-sdk v0.0.12/go.mod h1:/5oCswBe0pg/6GAuviqJErMxGgQWx+/OOD7UQ74d1FY=
 github.com/harness-io/harness-go-sdk v0.0.13 h1:bvjPh4s4gOmcVl1j1EyDppb895NAbjz03qfoBiBPJ7c=
 github.com/harness-io/harness-go-sdk v0.0.13/go.mod h1:/5oCswBe0pg/6GAuviqJErMxGgQWx+/OOD7UQ74d1FY=
+github.com/harness-io/harness-go-sdk v0.0.14 h1:rP81qvpUOBWmS/M2Xn12YfFOS9N4VWp2fVEDyRTMzTk=
+github.com/harness-io/harness-go-sdk v0.0.14/go.mod h1:/5oCswBe0pg/6GAuviqJErMxGgQWx+/OOD7UQ74d1FY=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/internal/provider/cloudprovider.go
+++ b/internal/provider/cloudprovider.go
@@ -19,6 +19,7 @@ func commonCloudProviderSchema() map[string]*schema.Schema {
 			Description: "The name of the cloud provider.",
 			Type:        schema.TypeString,
 			Required:    true,
+			ForceNew:    true,
 		},
 		"usage_scope": usageScopeSchema(),
 	}

--- a/internal/provider/cloudprovider.go
+++ b/internal/provider/cloudprovider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"log"
 
 	"github.com/harness-io/harness-go-sdk/harness/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -26,6 +27,7 @@ func commonCloudProviderSchema() map[string]*schema.Schema {
 }
 
 func resourceCloudProviderDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] Deleting cloud provider %s", d.Get("name"))
 	c := meta.(*api.Client)
 
 	id := d.Get("id").(string)

--- a/internal/provider/resource_cloudprovider_aws.go
+++ b/internal/provider/resource_cloudprovider_aws.go
@@ -80,7 +80,7 @@ func resourceCloudProviderAws() *schema.Resource {
 	helpers.MergeSchemas(commonSchema, providerSchema)
 
 	return &schema.Resource{
-		Description:   "Resource for creating an AWS cloud provider",
+		Description:   configAsCodeDescription("Resource for creating an AWS cloud provider."),
 		CreateContext: resourceCloudProviderAwsCreateOrUpdate,
 		ReadContext:   resourceCloudProviderAwsRead,
 		UpdateContext: resourceCloudProviderAwsCreateOrUpdate,

--- a/internal/provider/resource_cloudprovider_azure.go
+++ b/internal/provider/resource_cloudprovider_azure.go
@@ -46,7 +46,7 @@ func resourceCloudProviderAzure() *schema.Resource {
 	helpers.MergeSchemas(commonSchema, providerSchema)
 
 	return &schema.Resource{
-		Description:   "Resource for creating an Azure cloud provider",
+		Description:   configAsCodeDescription("Resource for creating an Azure cloud provider."),
 		CreateContext: resourceCloudProviderAzureCreateOrUpdate,
 		ReadContext:   resourceCloudProviderAzureRead,
 		UpdateContext: resourceCloudProviderAzureCreateOrUpdate,

--- a/internal/provider/resource_cloudprovider_datacenter.go
+++ b/internal/provider/resource_cloudprovider_datacenter.go
@@ -14,7 +14,7 @@ func resourceCloudProviderDataCenter() *schema.Resource {
 	providerSchema := commonCloudProviderSchema()
 
 	return &schema.Resource{
-		Description:   "Resource for creating a physical data center cloud provider",
+		Description:   configAsCodeDescription("Resource for creating a physical data center cloud provider."),
 		CreateContext: resourceCloudProviderDataCenterCreateOrUpdate,
 		ReadContext:   resourceCloudProviderDataCenterRead,
 		UpdateContext: resourceCloudProviderDataCenterCreateOrUpdate,

--- a/internal/provider/resource_cloudprovider_gcp.go
+++ b/internal/provider/resource_cloudprovider_gcp.go
@@ -40,7 +40,7 @@ func resourceCloudProviderGcp() *schema.Resource {
 	helpers.MergeSchemas(commonCloudProviderSchema(), providerSchema)
 
 	return &schema.Resource{
-		Description:   "Resource for creating a GCP cloud provider",
+		Description:   configAsCodeDescription("Resource for creating a GCP cloud provider."),
 		CreateContext: resourceCloudProviderGcpCreateOrUpdate,
 		ReadContext:   resourceCloudProviderGcpRead,
 		UpdateContext: resourceCloudProviderGcpCreateOrUpdate,

--- a/internal/provider/resource_cloudprovider_kubernetes_test.go
+++ b/internal/provider/resource_cloudprovider_kubernetes_test.go
@@ -16,6 +16,7 @@ func TestAccResourceK8sCloudProviderConnector_delegate(t *testing.T) {
 
 	var (
 		name         = fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(4))
+		updatedName  = fmt.Sprintf("%s_updated", name)
 		resourceName = "harness_cloudprovider_kubernetes.test"
 	)
 
@@ -29,6 +30,13 @@ func TestAccResourceK8sCloudProviderConnector_delegate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					testAccCheckK8sCloudProviderExists(t, resourceName, name),
+				),
+			},
+			{
+				Config: testAccResourceK8sCloudProvider_delegate(updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					testAccCheckK8sCloudProviderExists(t, resourceName, updatedName),
 				),
 			},
 			{

--- a/internal/provider/resource_cloudprovider_spot.go
+++ b/internal/provider/resource_cloudprovider_spot.go
@@ -32,7 +32,7 @@ func resourceCloudProviderSpot() *schema.Resource {
 	helpers.MergeSchemas(commonSchema, providerSchema)
 
 	return &schema.Resource{
-		Description:   "Resource for creating a Spot cloud provider",
+		Description:   configAsCodeDescription("Resource for creating a Spot cloud provider."),
 		CreateContext: resourceCloudProviderSpotCreateOrUpdate,
 		ReadContext:   resourceCloudProviderSpotRead,
 		UpdateContext: resourceCloudProviderSpotCreateOrUpdate,

--- a/internal/provider/resource_cloudprovider_tanzu.go
+++ b/internal/provider/resource_cloudprovider_tanzu.go
@@ -50,7 +50,7 @@ func resourceCloudProviderTanzu() *schema.Resource {
 	helpers.MergeSchemas(commonSchema, providerSchema)
 
 	return &schema.Resource{
-		Description:   "Resource for creating a Tanzu cloud provider",
+		Description:   configAsCodeDescription("Resource for creating a Tanzu cloud provider."),
 		CreateContext: resourceCloudProviderTanzuCreateOrUpdate,
 		ReadContext:   resourceCloudProviderTanzuRead,
 		UpdateContext: resourceCloudProviderTanzuCreateOrUpdate,

--- a/internal/provider/resource_infrastructure_definition.go
+++ b/internal/provider/resource_infrastructure_definition.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"log"
 	"strings"
 
 	"github.com/harness-io/harness-go-sdk/harness/api"
@@ -15,7 +16,7 @@ func resourceInfraDefinition() *schema.Resource {
 	infraDefSchema := infraDefSchema()
 
 	return &schema.Resource{
-		Description:   "Resource for creating am infrastructure definition",
+		Description:   configAsCodeDescription("Resource for creating am infrastructure definition."),
 		CreateContext: resourceInfraDefinitionCreateOrUpdate,
 		ReadContext:   resourceInfraDefinitionRead,
 		UpdateContext: resourceInfraDefinitionCreateOrUpdate,
@@ -43,6 +44,7 @@ func resourceInfraDefinitionRead(ctx context.Context, d *schema.ResourceData, me
 	appId := d.Get("app_id").(string)
 	envId := d.Get("env_id").(string)
 
+	log.Printf("[DEBUG] Terraform: Read infrastructure definition %s", id)
 	infraDef, err := c.ConfigAsCode().GetInfraDefinitionById(appId, envId, id)
 	if err != nil {
 		return diag.FromErr(err)
@@ -64,6 +66,7 @@ func resourceInfraDefinitionDelete(ctx context.Context, d *schema.ResourceData, 
 	appId := d.Get("app_id").(string)
 	envId := d.Get("env_id").(string)
 
+	log.Printf("[DEBUG] Terraform: Delete infrastructure definition %s", id)
 	err := c.ConfigAsCode().DeleteInfraDefinition(appId, envId, id)
 	if err != nil {
 		return diag.FromErr(err)
@@ -79,11 +82,13 @@ func resourceInfraDefinitionCreateOrUpdate(ctx context.Context, d *schema.Resour
 	var err error
 
 	if d.IsNewResource() {
+		log.Printf("[DEBUG] Terraform: Create infrastructure definition %s", d.Get("name"))
 		input = cac.NewEntity(cac.ObjectTypes.InfrastructureDefinition).(*cac.InfrastructureDefinition)
 	} else {
 		id := d.Get("id").(string)
 		appId := d.Get("app_id").(string)
 		envId := d.Get("env_id").(string)
+		log.Printf("[DEBUG] Terraform: Updating infrastructure definition %s", d.Get("name"))
 		input, err = c.ConfigAsCode().GetInfraDefinitionById(appId, envId, id)
 		if err != nil {
 			return diag.FromErr(err)

--- a/internal/provider/resource_service_ami.go
+++ b/internal/provider/resource_service_ami.go
@@ -11,7 +11,7 @@ import (
 
 func resourceAMIService() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Resource for creating an AMI service",
+		Description:   configAsCodeDescription("Resource for creating an AMI service."),
 		CreateContext: resourceAMIServiceCreateOrUpdate,
 		ReadContext:   resourceAMIServiceRead,
 		UpdateContext: resourceAMIServiceCreateOrUpdate,

--- a/internal/provider/resource_service_aws_codedeploy.go
+++ b/internal/provider/resource_service_aws_codedeploy.go
@@ -11,7 +11,7 @@ import (
 
 func resourceAWSCodeDeployService() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Resource for creating an AWS CodeDeploy service",
+		Description:   configAsCodeDescription("Resource for creating an AWS CodeDeploy service."),
 		CreateContext: resourceAWSCodeDeployServiceCreateOrUpdate,
 		ReadContext:   resourceAWSCodeDeployServiceRead,
 		UpdateContext: resourceAWSCodeDeployServiceCreateOrUpdate,

--- a/internal/provider/resource_service_aws_lambda.go
+++ b/internal/provider/resource_service_aws_lambda.go
@@ -11,7 +11,7 @@ import (
 
 func resourceAWSLambdaService() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Resource for creating an AWS Lambda service",
+		Description:   configAsCodeDescription("Resource for creating an AWS Lambda service."),
 		CreateContext: resourceAWSLambdaServiceCreateOrUpdate,
 		ReadContext:   resourceAWSLambdaServiceRead,
 		UpdateContext: resourceAWSLambdaServiceCreateOrUpdate,

--- a/internal/provider/resource_service_ecs.go
+++ b/internal/provider/resource_service_ecs.go
@@ -11,7 +11,7 @@ import (
 
 func resourceECSService() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Resource for creating an AWS ECS service",
+		Description:   configAsCodeDescription("Resource for creating an AWS ECS service."),
 		CreateContext: resourceECSServiceCreateOrUpdate,
 		ReadContext:   resourceECSServiceRead,
 		UpdateContext: resourceECSServiceCreateOrUpdate,

--- a/internal/provider/resource_service_helm.go
+++ b/internal/provider/resource_service_helm.go
@@ -11,7 +11,7 @@ import (
 
 func resourceHelmService() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Resource for creating a Kubernetes Helm service",
+		Description:   configAsCodeDescription("Resource for creating a Kubernetes Helm service."),
 		CreateContext: resourceHelmServiceCreateOrUpdate,
 		ReadContext:   resourceHelmServiceRead,
 		UpdateContext: resourceHelmServiceCreateOrUpdate,

--- a/internal/provider/resource_service_kubernetes.go
+++ b/internal/provider/resource_service_kubernetes.go
@@ -22,7 +22,7 @@ func resourceKubernetesService() *schema.Resource {
 	}
 
 	return &schema.Resource{
-		Description:   "Resource for creating a Kubernetes service",
+		Description:   configAsCodeDescription("Resource for creating a Kubernetes service."),
 		CreateContext: resourceKubernetesServiceCreateOrUpdate,
 		ReadContext:   resourceKubernetesServiceKubernetesRead,
 		UpdateContext: resourceKubernetesServiceCreateOrUpdate,

--- a/internal/provider/resource_service_ssh.go
+++ b/internal/provider/resource_service_ssh.go
@@ -22,7 +22,7 @@ func resourceSSHService() *schema.Resource {
 	}
 
 	return &schema.Resource{
-		Description:   "Resource for creating an SSH service",
+		Description:   configAsCodeDescription("Resource for creating an SSH service."),
 		CreateContext: resourceSSHServiceCreateOrUpdate,
 		ReadContext:   resourceSSHServiceRead,
 		UpdateContext: resourceSSHServiceCreateOrUpdate,

--- a/internal/provider/resource_service_tanzu.go
+++ b/internal/provider/resource_service_tanzu.go
@@ -11,7 +11,7 @@ import (
 
 func resourcePCFService() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Resource for creating a Tanzu (PCF) service",
+		Description:   configAsCodeDescription("Resource for creating a Tanzu (PCF) service."),
 		CreateContext: resourceTanzuServiceCreateOrUpdate,
 		ReadContext:   resourceTanzuServiceRead,
 		UpdateContext: resourceTanzuServiceCreateOrUpdate,

--- a/internal/provider/resource_service_winrm.go
+++ b/internal/provider/resource_service_winrm.go
@@ -22,7 +22,7 @@ func resourceWinRMService() *schema.Resource {
 	}
 
 	return &schema.Resource{
-		Description:   "Resource for creating an WinRM service",
+		Description:   configAsCodeDescription("Resource for creating an WinRM service."),
 		CreateContext: resourceWinRMServiceCreateOrUpdate,
 		ReadContext:   resourceWinRMServiceRead,
 		UpdateContext: resourceWinRMServiceCreateOrUpdate,

--- a/internal/provider/resource_yaml_config.go
+++ b/internal/provider/resource_yaml_config.go
@@ -14,7 +14,7 @@ import (
 func resourceYamlConfig() *schema.Resource {
 
 	return &schema.Resource{
-		Description:   "Resource for creating a raw YAML configuration in Harness. Note: This works for all objects EXCEPT application objects.",
+		Description:   configAsCodeDescription("Resource for creating a raw YAML configuration in Harness. Note: This works for all objects EXCEPT application objects."),
 		CreateContext: resourceYamlConfigCreateOrUpdate,
 		ReadContext:   resourceYamlConfigRead,
 		UpdateContext: resourceYamlConfigCreateOrUpdate,

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -1,5 +1,13 @@
 package provider
 
+import "fmt"
+
+const cacDescription string = "This object uses the config-as-code API's. When updating the `name` or `path` of this resource you should typically also set the `create_before_destroy = true` lifecycle setting."
+
+func configAsCodeDescription(descripton string) string {
+	return fmt.Sprintf("%s %s", descripton, cacDescription)
+}
+
 func expandDelegateSelectors(ds []interface{}) []string {
 	selectors := make([]string, 0)
 


### PR DESCRIPTION
Closes #29 . 

- Force new resource when changing the name of a cloud provider.
- Updates documentation recommending using `create_before_destroy` lifecycle flag.