### PR TITLE
Modify 2fa_enabled to use a letter first

### DIFF
--- a/.changelog/75.txt
+++ b/.changelog/75.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/harness_current_user: Change `2fa_enabled` to `is_two_factor_auth_enabled` to support `cdk` usage.
+```

--- a/docs/data-sources/current_user.md
+++ b/docs/data-sources/current_user.md
@@ -21,7 +21,7 @@ description: |-
 
 ### Read-Only
 
-- **2fa_enabled** (Boolean) Whether 2FA is enabled for the user.
+- **is_two_factor_auth_enabled** (Boolean) Whether 2FA is enabled for the user.
 - **admin** (Boolean) Whether the user is an administrator.
 - **billing_frequency** (String) Billing frequency of the user.
 - **default_account_id** (String) Default account ID of the user.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -151,7 +151,6 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 			DebugLogging: logging.IsDebugOrHigher(),
 			HTTPClient:   getHttpClient(),
 		})
-
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}

--- a/internal/service/ng/data_source_current_user.go
+++ b/internal/service/ng/data_source_current_user.go
@@ -52,7 +52,7 @@ func DataSourceCurrentUser() *schema.Resource {
 				Type:        schema.TypeBool,
 				Computed:    true,
 			},
-			"2fa_enabled": {
+			"is_two_factor_auth_enabled": {
 				Description: "Whether 2FA is enabled for the user.",
 				Type:        schema.TypeBool,
 				Computed:    true,
@@ -102,7 +102,7 @@ func dataSourceCurrentUserRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("default_account_id", user.DefaultAccountId)
 	d.Set("intent", user.Intent)
 	d.Set("admin", user.Admin)
-	d.Set("2fa_enabled", user.TwoFactorAuthenticationEnabled)
+	d.Set("is_two_factor_auth_enabled", user.TwoFactorAuthenticationEnabled)
 	d.Set("email_verified", user.EmailVerified)
 	d.Set("locked", user.Locked)
 	d.Set("signup_action", user.SignupAction)


### PR DESCRIPTION
Relating to https://github.com/harness-io/terraform-provider-harness/issues/74 
Removing number first parameter to allow auto generation of code from terraform CDK and pulumi.