### PR TITLE
Fixed issue with environment data source lookup by id

### DIFF
--- a/.changelog/81.txt
+++ b/.changelog/81.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/harness_environment: Replaces `id` field with `environment_id` so `id` field can be marked as computed.
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.1.14 (Unreleased)
+
 # 0.1.13
 
 FEATURES:

--- a/docs/data-sources/environment.md
+++ b/docs/data-sources/environment.md
@@ -21,12 +21,13 @@ Data source for retrieving a Harness service
 
 ### Optional
 
-- **id** (String) The id of the environment.
+- **environment_id** (String) The id of the environment.
 - **name** (String) The name of the environment.
 
 ### Read-Only
 
 - **description** (String) The description of the environment.
+- **id** (String) The id of the environment.
 - **type** (String) The type of the environment. Valid values are `PROD` and `NON_PROD`
 - **variable_override** (Block Set) Override for a service variable (see [below for nested schema](#nestedblock--variable_override))
 

--- a/internal/service/cd/environment/environment_data_source.go
+++ b/internal/service/cd/environment/environment_data_source.go
@@ -18,10 +18,15 @@ func DataSourceEnvironment() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"id": {
+				Description: "The id of the environment.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"environment_id": {
 				Description:   "The id of the environment.",
 				Type:          schema.TypeString,
 				Optional:      true,
-				AtLeastOneOf:  []string{"id", "name"},
+				AtLeastOneOf:  []string{"environment_id", "name"},
 				ConflictsWith: []string{"name"},
 			},
 			"app_id": {
@@ -33,8 +38,8 @@ func DataSourceEnvironment() *schema.Resource {
 				Description:   "The name of the environment.",
 				Type:          schema.TypeString,
 				Optional:      true,
-				AtLeastOneOf:  []string{"id", "name"},
-				ConflictsWith: []string{"id"},
+				AtLeastOneOf:  []string{"environment_id", "name"},
+				ConflictsWith: []string{"environment_id"},
 			},
 			"description": {
 				Description: "The description of the environment.",
@@ -88,7 +93,7 @@ func dataSourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta
 
 	appId := d.Get("app_id").(string)
 
-	if id := d.Get("id").(string); id != "" {
+	if id := d.Get("environment_id").(string); id != "" {
 		env, err = c.CDClient.ConfigAsCodeClient.GetEnvironmentById(appId, id)
 		if err != nil {
 			return diag.FromErr(err)
@@ -105,6 +110,7 @@ func dataSourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	d.SetId(env.Id)
+	d.Set("environment_id", env.Id)
 	d.Set("app_id", env.ApplicationId)
 	d.Set("name", env.Name)
 	d.Set("type", env.EnvironmentType)

--- a/internal/service/cd/environment/environment_data_source_test.go
+++ b/internal/service/cd/environment/environment_data_source_test.go
@@ -66,7 +66,7 @@ func testAccDataSourceEnvironmentById(name string, envType cac.EnvironmentType) 
 
 	data "harness_environment" "test" {
 		app_id = harness_application.test.id
-		id = harness_environment.test.id
+		environment_id = harness_environment.test.id
 	}
 
 	`, name, envType)


### PR DESCRIPTION
Adds `environment_id`  to `data "harness_environment"` for looking up an environment. This allows `id` to be set as computed and can be referenced.

Closes #79