### PR TITLE
fix: [CDS-100941]: Make account id optional in gitops data resources.

### DIFF
--- a/internal/service/platform/gitops/agent/data_source_gitops_agent.go
+++ b/internal/service/platform/gitops/agent/data_source_gitops_agent.go
@@ -24,6 +24,7 @@ func DataSourceGitopsAgent() *schema.Resource {
 				Description: "Account identifier of the GitOps agent.",
 				Type:        schema.TypeString,
 				Computed:    true,
+				Optional:    true,
 				Deprecated:  "This field is deprecated and will be removed in a future release.",
 			},
 			"project_id": {

--- a/internal/service/platform/gitops/agent_yaml/data_source_gitops_agent_deploy_yaml.go
+++ b/internal/service/platform/gitops/agent_yaml/data_source_gitops_agent_deploy_yaml.go
@@ -20,6 +20,7 @@ func DataSourceGitopsAgentDeployYaml() *schema.Resource {
 				Description: "Account identifier of the GitOps agent.",
 				Type:        schema.TypeString,
 				Computed:    true,
+				Optional:    true,
 				Deprecated:  "This field is deprecated and will be removed in a future release.",
 			},
 			"project_id": {

--- a/internal/service/platform/gitops/app_project/datasource_gitops_app_project_mapping.go
+++ b/internal/service/platform/gitops/app_project/datasource_gitops_app_project_mapping.go
@@ -23,6 +23,7 @@ func DatasourceGitopsAppProjectMapping() *schema.Resource {
 				Description: "Account identifier of the GitOps agent's Application Project.",
 				Type:        schema.TypeString,
 				Computed:    true,
+				Optional:    true,
 				Deprecated:  "This field is deprecated and will be removed in a future release.",
 			},
 			"org_id": {

--- a/internal/service/platform/gitops/applications/datasource_gitops_applications.go
+++ b/internal/service/platform/gitops/applications/datasource_gitops_applications.go
@@ -20,6 +20,7 @@ func DataSourceGitopsApplications() *schema.Resource {
 				Description: "Account identifier of the GitOps application.",
 				Type:        schema.TypeString,
 				Computed:    true,
+				Optional:    true,
 				Deprecated:  "This field is deprecated and will be removed in a future release.",
 			},
 			"org_id": {

--- a/internal/service/platform/gitops/cluster/data_source_gitops_cluster.go
+++ b/internal/service/platform/gitops/cluster/data_source_gitops_cluster.go
@@ -22,6 +22,7 @@ func DataSourceGitopsCluster() *schema.Resource {
 				Description: "Account identifier of the GitOps cluster.",
 				Type:        schema.TypeString,
 				Computed:    true,
+				Optional:    true,
 				Deprecated:  "This field is deprecated and will be removed in a future release.",
 			},
 			"project_id": {

--- a/internal/service/platform/gitops/gnupg/data_source_gnupg.go
+++ b/internal/service/platform/gitops/gnupg/data_source_gnupg.go
@@ -23,6 +23,7 @@ func DataSourceGitopsGnupg() *schema.Resource {
 				Description: "Account Identifier for the GnuPG Key.",
 				Type:        schema.TypeString,
 				Computed:    true,
+				Optional:    true,
 				Deprecated:  "This field is deprecated and will be removed in a future release.",
 			},
 			"org_id": {

--- a/internal/service/platform/gitops/project/data_source_gitops_app_project.go
+++ b/internal/service/platform/gitops/project/data_source_gitops_app_project.go
@@ -24,6 +24,7 @@ func DataSourceGitOpsProject() *schema.Resource {
 				Description: "Account identifier of the GitOps Agent where argo project resides.",
 				Type:        schema.TypeString,
 				Computed:    true,
+				Optional:    true,
 				Deprecated:  "This field is deprecated and will be removed in a future release.",
 			},
 			"org_id": {

--- a/internal/service/platform/gitops/repository/data_source_gitops_repository.go
+++ b/internal/service/platform/gitops/repository/data_source_gitops_repository.go
@@ -22,6 +22,7 @@ func DataSourceGitopsRepository() *schema.Resource {
 				Description: "Account identifier of the GitOps repository.",
 				Type:        schema.TypeString,
 				Computed:    true,
+				Optional:    true,
 				Deprecated:  "This field is deprecated and will be removed in a future release.",
 			},
 			"org_id": {

--- a/internal/service/platform/gitops/repository_certificates/data_source_gitops_repo_cert.go
+++ b/internal/service/platform/gitops/repository_certificates/data_source_gitops_repo_cert.go
@@ -28,6 +28,7 @@ func DataSourceGitOpsRepoCert() *schema.Resource {
 				Description: "Account identifier of the GitOps repository certificate.",
 				Type:        schema.TypeString,
 				Computed:    true,
+				Optional:    true,
 				Deprecated:  "This field is deprecated and will be removed in a future release.",
 			},
 			"org_id": {

--- a/internal/service/platform/gitops/repository_credentials/data_source_gitops_repo_cred.go
+++ b/internal/service/platform/gitops/repository_credentials/data_source_gitops_repo_cred.go
@@ -28,6 +28,7 @@ func DataSourceGitOpsRepoCred() *schema.Resource {
 				Description: "Account identifier of the Repository Credentials.",
 				Type:        schema.TypeString,
 				Computed:    true,
+				Optional:    true,
 				Deprecated:  "This field is deprecated and will be removed in a future release.",
 			},
 			"identifier": {


### PR DESCRIPTION

**Title:** GitOps deprecate accountId

**Summary:**

Since account id may be in existing data config, even though it is not required for fetching resource we cant make it just computed, must be optional too.

**Details:**
Explain the changes in detail, including any relevant context or background information.

**Related Issues:**
Reference any related issues or tickets 

**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes should be done)
- Update the resource and execute terraform apply. (Verify the resource updated successfully)
- Remove the content from resource file and execute terraform apply. (Verify the resource has been deleted)
- Add again the resource and execute the terraform apply. (Verify the resource is created)
- Verify the import the resource file is working fine.
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
