### PR TITLE
fix the error of not setting spot split as 100 when on demand is 0

### DIFF
--- a/internal/service/platform/cluster_orchestrator/service.go
+++ b/internal/service/platform/cluster_orchestrator/service.go
@@ -42,10 +42,11 @@ func buildClusterOrchConfig(d *schema.ResourceData) nextgen.ClusterOrchConfig {
 	if attr, ok := d.GetOk("distribution.0.base_ondemand_capacity"); ok {
 		config.BaseOnDemandCapacity = attr.(int)
 	}
-	if attr, ok := d.GetOk("distribution.0.ondemand_replica_percentage"); ok {
-		config.OnDemandSplit = int(attr.(float64))
-		config.SpotSplit = 100 - config.OnDemandSplit
-	}
+
+	attr := d.Get("distribution.0.ondemand_replica_percentage").(float64)
+	config.OnDemandSplit = int(attr)
+	config.SpotSplit = 100 - config.OnDemandSplit
+
 	if attr, ok := d.GetOk("distribution.0.selector"); ok {
 		config.SpotDistribution = nextgen.ClusterOrchDistributionSelector(attr.(string))
 	}


### PR DESCRIPTION
**Title:** [Component/Feature] Short Description of the Change

**Summary:**
Provide a brief overview of what the PR does and why it is needed.

**Details:**
Explain the changes in detail, including any relevant context or background information.

**Related Issues:**
Reference any related issues or tickets 

**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes should be done)
- Update the resource and execute terraform apply. (Verify the resource updated successfully)
- Remove the content from resource file and execute terraform apply. (Verify the resource has been deleted)
- Add again the resource and execute the terraform apply. (Verify the resource is created)
- Verify the import the resource file is working fine.
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
