### PR TITLE
fix: issue with idp api and account id param

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -742,13 +742,12 @@ func getHarClient(d *schema.ResourceData, version string) *har.APIClient {
 func getIDPClient(d *schema.ResourceData, version string) *idp.APIClient {
 	cfg := idp.NewConfiguration()
 	client := idp.NewAPIClient(&idp.Configuration{
-		AccountId:     d.Get("account_id").(string),
-		BasePath:      d.Get("endpoint").(string),
-		ApiKey:        d.Get("platform_api_key").(string),
-		UserAgent:     fmt.Sprintf("terraform-provider-harness-platform-%s", version),
-		HTTPClient:    getOpenApiHttpClient(cfg.Logger),
-		DefaultHeader: map[string]string{"X-Api-Key": d.Get("platform_api_key").(string)},
-		DebugLogging:  openapi_client_logging.IsDebugOrHigher(cfg.Logger),
+		AccountId:    d.Get("account_id").(string),
+		BasePath:     d.Get("endpoint").(string),
+		ApiKey:       d.Get("platform_api_key").(string),
+		UserAgent:    fmt.Sprintf("terraform-provider-harness-platform-%s", version),
+		HTTPClient:   getOpenApiHttpClient(cfg.Logger),
+		DebugLogging: openapi_client_logging.IsDebugOrHigher(cfg.Logger),
 	})
 	return client
 }

--- a/internal/session.go
+++ b/internal/session.go
@@ -112,7 +112,7 @@ func (s *Session) GetIDPClientWithContext(ctx context.Context) (*idp.APIClient, 
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return s.IDPClient, ctx
+	return s.IDPClient.WithAuthContext(ctx)
 }
 
 func (s *Session) GetPOClientWithContext(ctx context.Context) (*po.APIClient, context.Context) {


### PR DESCRIPTION
**Title:** [Component/Feature] Short Description of the Change

**Summary:**

  Problem

  The harness_platform_idp_catalog_entity resource fails with 401 Unauthorized on Read operations after Create succeeds. This breaks Terraform state management for IDP entities.

  Root Cause

  Two issues:

  1. Provider: GetIDPClientWithContext() doesn't call .WithAuthContext(ctx), so the API key never gets added to the request context.
  2. SDK: The IDP API requires accountIdentifier as a query parameter for GET requests, but the SDK only sends it as a header.

  Verified with curl:
  - GET /gateway/v1/entities/account/workflow/{id} with Harness-Account header only → 401
  - GET /gateway/v1/entities/account/workflow/{id}?accountIdentifier={id} → 200

  ---
  PR # 1 (THIS PR): terraform-provider-harness

  Title: fix: Add WithAuthContext to GetIDPClientWithContext

  File: internal/session.go

  Change:
  func (s *Session) GetIDPClientWithContext(ctx context.Context) (*idp.APIClient, context.Context) {
      if ctx == nil {
          ctx = context.Background()
      }
      return s.IDPClient.WithAuthContext(ctx)  // was: return s.IDPClient, ctx
  }

  Why:
  Every other client method (GetPlatformClientWithContext, GetDBOpsClientWithContext, etc.) calls .WithAuthContext(ctx) to inject the API key. This one was missing it.

  Requires: The SDK fix below to work fully.

  ---
[  PR #2: harness-go-sdk](https://github.com/harness/harness-go-sdk/pull/702)

  Title: fix(idp): Add accountIdentifier query param to GetEntity

  File: harness/idp/api_entities.go

  Change (add after line 740):
  if localVarOptionals != nil && localVarOptionals.HarnessAccount.IsSet() {
      localVarQueryParams.Add("accountIdentifier", parameterToString(localVarOptionals.HarnessAccount.Value(), ""))
  }

  Why:
  The IDP API needs accountIdentifier as a query parameter for GET requests when using API key auth. Currently only sent as Harness-Account header, which isn't enough.

  Other methods (Create/Update/Delete) work fine with just the header. This seems to be a GET-specific API requirement.

  ---
  Both fixes needed for the resource to work correctly.

**Details:**
Explain the changes in detail, including any relevant context or background information.

**Related Issues:**
Reference any related issues or tickets 

**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes should be done)
- Update the resource and execute terraform apply. (Verify the resource updated successfully)
- Remove the content from resource file and execute terraform apply. (Verify the resource has been deleted)
- Add again the resource and execute the terraform apply. (Verify the resource is created)
- Verify the import the resource file is working fine.
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
