### PR TITLE
fix(gitops): source optional in appset templ spec to support multi-source

### DIFF
--- a/.changelog/1388.txt
+++ b/.changelog/1388.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+harness_platform_gitops_applicationset: Make the singular `source` block optional in the Application template spec so ApplicationSets can be defined with multiple `sources` (ArgoCD multi-source) alone. Previously a `sources`-only template failed with "At least 1 source blocks are required". The provider now validates at plan time that a template sets exactly one of `source` or `sources`.
+```

--- a/docs/resources/platform_gitops_applicationset.md
+++ b/docs/resources/platform_gitops_applicationset.md
@@ -344,8 +344,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--cluster_decision_resource--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--cluster_decision_resource--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--cluster_decision_resource--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--cluster_decision_resource--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--cluster_decision_resource--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--cluster_decision_resource--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--cluster_decision_resource--template--spec--destination"></a>
@@ -749,8 +749,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--clusters--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--clusters--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--clusters--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--clusters--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--clusters--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--clusters--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--clusters--template--spec--destination"></a>
@@ -1160,8 +1160,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--git--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--git--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--git--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--git--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--git--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--git--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--git--template--spec--destination"></a>
@@ -1547,8 +1547,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--list--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--list--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--list--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--list--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--list--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--list--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--list--template--spec--destination"></a>
@@ -1983,8 +1983,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--cluster_decision_resource--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--cluster_decision_resource--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--cluster_decision_resource--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--cluster_decision_resource--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--cluster_decision_resource--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--cluster_decision_resource--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--cluster_decision_resource--template--spec--destination"></a>
@@ -2388,8 +2388,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--clusters--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--clusters--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--clusters--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--clusters--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--clusters--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--clusters--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--clusters--template--spec--destination"></a>
@@ -2799,8 +2799,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--git--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--git--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--git--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--git--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--git--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--git--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--git--template--spec--destination"></a>
@@ -3186,8 +3186,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--list--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--list--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--list--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--list--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--list--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--list--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--list--template--spec--destination"></a>
@@ -3620,8 +3620,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--cluster_decision_resource--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--cluster_decision_resource--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--cluster_decision_resource--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--cluster_decision_resource--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--cluster_decision_resource--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--cluster_decision_resource--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--cluster_decision_resource--template--spec--destination"></a>
@@ -4025,8 +4025,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--clusters--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--clusters--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--clusters--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--clusters--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--clusters--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--clusters--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--clusters--template--spec--destination"></a>
@@ -4436,8 +4436,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--git--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--git--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--git--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--git--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--git--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--git--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--git--template--spec--destination"></a>
@@ -4823,8 +4823,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--list--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--list--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--list--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--list--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--list--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--list--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--list--template--spec--destination"></a>
@@ -5325,8 +5325,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--pull_request--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--pull_request--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--pull_request--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--pull_request--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--pull_request--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--pull_request--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--pull_request--template--spec--destination"></a>
@@ -5890,8 +5890,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--scm_provider--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--scm_provider--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--scm_provider--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--scm_provider--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--scm_provider--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--scm_provider--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--matrix--generator--scm_provider--template--spec--destination"></a>
@@ -6286,8 +6286,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--matrix--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--matrix--template--spec--destination"></a>
@@ -6721,8 +6721,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--cluster_decision_resource--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--cluster_decision_resource--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--cluster_decision_resource--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--cluster_decision_resource--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--cluster_decision_resource--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--cluster_decision_resource--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--cluster_decision_resource--template--spec--destination"></a>
@@ -7126,8 +7126,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--clusters--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--clusters--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--clusters--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--clusters--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--clusters--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--clusters--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--clusters--template--spec--destination"></a>
@@ -7537,8 +7537,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--git--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--git--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--git--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--git--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--git--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--git--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--git--template--spec--destination"></a>
@@ -7924,8 +7924,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--list--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--list--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--list--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--list--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--list--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--list--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--list--template--spec--destination"></a>
@@ -8426,8 +8426,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--pull_request--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--pull_request--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--pull_request--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--pull_request--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--pull_request--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--pull_request--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--pull_request--template--spec--destination"></a>
@@ -8991,8 +8991,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--scm_provider--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--scm_provider--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--scm_provider--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--scm_provider--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--scm_provider--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--scm_provider--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--merge--generator--scm_provider--template--spec--destination"></a>
@@ -9387,8 +9387,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--merge--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--merge--template--spec--destination"></a>
@@ -9889,8 +9889,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--pull_request--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--pull_request--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--pull_request--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--pull_request--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--pull_request--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--pull_request--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--pull_request--template--spec--destination"></a>
@@ -10454,8 +10454,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--scm_provider--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--scm_provider--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--scm_provider--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--scm_provider--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--scm_provider--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--generator--scm_provider--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--generator--scm_provider--template--spec--destination"></a>
@@ -10850,8 +10850,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--matrix--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--matrix--template--spec--destination"></a>
@@ -11287,8 +11287,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--cluster_decision_resource--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--cluster_decision_resource--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--cluster_decision_resource--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--cluster_decision_resource--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--cluster_decision_resource--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--cluster_decision_resource--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--cluster_decision_resource--template--spec--destination"></a>
@@ -11692,8 +11692,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--clusters--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--clusters--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--clusters--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--clusters--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--clusters--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--clusters--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--clusters--template--spec--destination"></a>
@@ -12103,8 +12103,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--git--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--git--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--git--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--git--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--git--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--git--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--git--template--spec--destination"></a>
@@ -12490,8 +12490,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--list--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--list--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--list--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--list--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--list--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--list--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--list--template--spec--destination"></a>
@@ -12924,8 +12924,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--cluster_decision_resource--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--cluster_decision_resource--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--cluster_decision_resource--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--cluster_decision_resource--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--cluster_decision_resource--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--cluster_decision_resource--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--cluster_decision_resource--template--spec--destination"></a>
@@ -13329,8 +13329,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--clusters--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--clusters--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--clusters--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--clusters--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--clusters--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--clusters--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--clusters--template--spec--destination"></a>
@@ -13740,8 +13740,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--git--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--git--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--git--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--git--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--git--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--git--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--git--template--spec--destination"></a>
@@ -14127,8 +14127,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--list--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--list--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--list--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--list--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--list--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--list--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--list--template--spec--destination"></a>
@@ -14629,8 +14629,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--pull_request--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--pull_request--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--pull_request--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--pull_request--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--pull_request--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--pull_request--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--pull_request--template--spec--destination"></a>
@@ -15194,8 +15194,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--scm_provider--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--scm_provider--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--scm_provider--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--scm_provider--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--scm_provider--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--scm_provider--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--matrix--generator--scm_provider--template--spec--destination"></a>
@@ -15590,8 +15590,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--matrix--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--matrix--template--spec--destination"></a>
@@ -16025,8 +16025,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--cluster_decision_resource--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--cluster_decision_resource--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--cluster_decision_resource--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--cluster_decision_resource--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--cluster_decision_resource--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--cluster_decision_resource--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--merge--generator--cluster_decision_resource--template--spec--destination"></a>
@@ -16430,8 +16430,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--clusters--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--clusters--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--clusters--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--clusters--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--clusters--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--clusters--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--merge--generator--clusters--template--spec--destination"></a>
@@ -16841,8 +16841,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--git--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--git--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--git--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--git--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--git--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--git--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--merge--generator--git--template--spec--destination"></a>
@@ -17228,8 +17228,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--list--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--list--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--list--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--list--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--list--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--list--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--merge--generator--list--template--spec--destination"></a>
@@ -17730,8 +17730,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--pull_request--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--pull_request--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--pull_request--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--pull_request--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--pull_request--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--pull_request--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--merge--generator--pull_request--template--spec--destination"></a>
@@ -18295,8 +18295,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--scm_provider--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--scm_provider--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--scm_provider--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--scm_provider--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--scm_provider--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--generator--scm_provider--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--merge--generator--scm_provider--template--spec--destination"></a>
@@ -18691,8 +18691,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--merge--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--merge--template--spec--destination"></a>
@@ -19193,8 +19193,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--pull_request--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--pull_request--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--pull_request--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--pull_request--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--pull_request--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--pull_request--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--pull_request--template--spec--destination"></a>
@@ -19758,8 +19758,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--scm_provider--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--scm_provider--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--scm_provider--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--scm_provider--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--scm_provider--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--generator--scm_provider--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--generator--scm_provider--template--spec--destination"></a>
@@ -20154,8 +20154,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--merge--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--merge--template--spec--destination"></a>
@@ -20656,8 +20656,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--pull_request--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--pull_request--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--pull_request--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--pull_request--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--pull_request--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--pull_request--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--pull_request--template--spec--destination"></a>
@@ -21221,8 +21221,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--generator--scm_provider--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `source` (Block List) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--generator--scm_provider--template--spec--source))
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--generator--scm_provider--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--scm_provider--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--generator--scm_provider--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--generator--scm_provider--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--generator--scm_provider--template--spec--destination"></a>
@@ -21616,7 +21616,6 @@ Optional:
 Required:
 
 - `destination` (Block List, Min: 1, Max: 1) Reference to the Kubernetes server and namespace in which the application will be deployed. (see [below for nested schema](#nestedblock--applicationset--spec--template--spec--destination))
-- `source` (Block List, Min: 1) Location of the application's manifests or chart. (see [below for nested schema](#nestedblock--applicationset--spec--template--spec--source))
 
 Optional:
 
@@ -21624,7 +21623,8 @@ Optional:
 - `info` (Block List) List of information (URLs, email addresses, and plain text) that relates to the application. (see [below for nested schema](#nestedblock--applicationset--spec--template--spec--info))
 - `project` (String) The project the application belongs to.
 - `revision_history_limit` (String) Limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
-- `sources` (Block List) Location of the application's manifests or chart. Use when specifying multiple fields (see [below for nested schema](#nestedblock--applicationset--spec--template--spec--sources))
+- `source` (Block List, Max: 1) Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--template--spec--source))
+- `sources` (Block List) List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`. (see [below for nested schema](#nestedblock--applicationset--spec--template--spec--sources))
 - `sync_policy` (Block List, Max: 1) Controls when and how a sync will be performed. (see [below for nested schema](#nestedblock--applicationset--spec--template--spec--sync_policy))
 
 <a id="nestedblock--applicationset--spec--template--spec--destination"></a>
@@ -21635,6 +21635,28 @@ Optional:
 - `name` (String) Name of the target cluster. Can be used instead of `server`.
 - `namespace` (String) Target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace.
 - `server` (String) URL of the target cluster and must be set to the Kubernetes control plane API.
+
+
+<a id="nestedblock--applicationset--spec--template--spec--ignore_difference"></a>
+### Nested Schema for `applicationset.spec.template.spec.ignore_difference`
+
+Optional:
+
+- `group` (String) The Kubernetes resource Group to match for.
+- `jq_path_expressions` (List of String) List of JQ path expression strings targeting the field(s) to ignore.
+- `json_pointers` (List of String) List of JSONPaths strings targeting the field(s) to ignore.
+- `kind` (String) The Kubernetes resource Kind to match for.
+- `name` (String) The Kubernetes resource Name to match for.
+- `namespace` (String) The Kubernetes resource Namespace to match for.
+
+
+<a id="nestedblock--applicationset--spec--template--spec--info"></a>
+### Nested Schema for `applicationset.spec.template.spec.info`
+
+Optional:
+
+- `name` (String) Name of the information.
+- `value` (String) Value of the information.
 
 
 <a id="nestedblock--applicationset--spec--template--spec--source"></a>
@@ -21767,28 +21789,6 @@ Optional:
 - `value` (String) Value of the environment variable.
 
 
-
-
-<a id="nestedblock--applicationset--spec--template--spec--ignore_difference"></a>
-### Nested Schema for `applicationset.spec.template.spec.ignore_difference`
-
-Optional:
-
-- `group` (String) The Kubernetes resource Group to match for.
-- `jq_path_expressions` (List of String) List of JQ path expression strings targeting the field(s) to ignore.
-- `json_pointers` (List of String) List of JSONPaths strings targeting the field(s) to ignore.
-- `kind` (String) The Kubernetes resource Kind to match for.
-- `name` (String) The Kubernetes resource Name to match for.
-- `namespace` (String) The Kubernetes resource Namespace to match for.
-
-
-<a id="nestedblock--applicationset--spec--template--spec--info"></a>
-### Nested Schema for `applicationset.spec.template.spec.info`
-
-Optional:
-
-- `name` (String) Name of the information.
-- `value` (String) Value of the information.
 
 
 <a id="nestedblock--applicationset--spec--template--spec--sources"></a>

--- a/internal/service/platform/gitops/applicationset/resource_gitops_applicationset.go
+++ b/internal/service/platform/gitops/applicationset/resource_gitops_applicationset.go
@@ -15,6 +15,7 @@ import (
 	"github.com/harness/terraform-provider-harness/internal/service/platform/gitops"
 	"github.com/harness/terraform-provider-harness/internal/service/platform/gitops/applications"
 	"github.com/harness/terraform-provider-harness/internal/utils"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -57,6 +58,13 @@ func ResourceGitopsApplicationSet() *schema.Resource {
 					e = fmt.Errorf("field 'name' cannot be changed after the resource is created:%w", e)
 				} else {
 					e = fmt.Errorf("field 'name' cannot be changed after the resource is created")
+				}
+			}
+			if srcErr := validateTemplateSpecSource(diff); srcErr != nil {
+				if e != nil {
+					e = fmt.Errorf("%v:%w", srcErr, e)
+				} else {
+					e = srcErr
 				}
 			}
 			return e
@@ -277,6 +285,79 @@ func ResourceGitopsApplicationSet() *schema.Resource {
 			},
 		},
 	}
+}
+
+// validateTemplateSpecSource enforces the ArgoCD contract that an Application
+// template must reference exactly one of `source` (single source) or `sources`
+// (multiple sources). The check is intentionally limited to the spec-level
+// template (applicationset.spec.template.spec). Generator-level template overrides
+// are partial and may legitimately omit both, so they are not validated here.
+func validateTemplateSpecSource(diff *schema.ResourceDiff) error {
+	templateSpec, ok := rawTemplateSpec(diff)
+	if !ok {
+		return nil
+	}
+	sourceCount, sourceOk := rawBlockLen(templateSpec, "source")
+	sourcesCount, sourcesOk := rawBlockLen(templateSpec, "sources")
+	if !sourceOk || !sourcesOk {
+		return nil
+	}
+	return checkExactlyOneSource(sourceCount, sourcesCount)
+}
+
+// checkExactlyOneSource validates that exactly one of the singular `source` or the
+// plural `sources` block is configured on an Application template spec.
+func checkExactlyOneSource(sourceCount, sourcesCount int) error {
+	if sourceCount == 0 && sourcesCount == 0 {
+		return fmt.Errorf("applicationset.spec.template.spec requires exactly one of 'source' or 'sources' to be set")
+	}
+	if sourceCount > 0 && sourcesCount > 0 {
+		return fmt.Errorf("applicationset.spec.template.spec fields 'source' and 'sources' are mutually exclusive; set only one")
+	}
+	return nil
+}
+
+// rawTemplateSpec navigates the raw config to the spec-level template spec object
+// (applicationset[0].spec[0].template[0].spec[0]). It returns ok=false when the
+// value is not statically known (e.g. computed/unknown), so validation is skipped.
+func rawTemplateSpec(diff *schema.ResourceDiff) (cty.Value, bool) {
+	cur := diff.GetRawConfig()
+	for _, attr := range []string{"applicationset", "spec", "template", "spec"} {
+		next, ok := rawFirstBlock(cur, attr)
+		if !ok {
+			return cty.NilVal, false
+		}
+		cur = next
+	}
+	return cur, true
+}
+
+// rawFirstBlock returns the first element of a block list attribute on obj.
+func rawFirstBlock(obj cty.Value, attr string) (cty.Value, bool) {
+	if obj.IsNull() || !obj.IsKnown() || !obj.Type().IsObjectType() || !obj.Type().HasAttribute(attr) {
+		return cty.NilVal, false
+	}
+	list := obj.GetAttr(attr)
+	if list.IsNull() || !list.IsKnown() || !list.CanIterateElements() || list.LengthInt() == 0 {
+		return cty.NilVal, false
+	}
+	return list.Index(cty.NumberIntVal(0)), true
+}
+
+// rawBlockLen returns the number of elements configured for a block list attribute
+// on obj. ok is false when the value cannot be determined statically.
+func rawBlockLen(obj cty.Value, attr string) (int, bool) {
+	if obj.IsNull() || !obj.IsKnown() || !obj.Type().IsObjectType() || !obj.Type().HasAttribute(attr) {
+		return 0, false
+	}
+	list := obj.GetAttr(attr)
+	if list.IsNull() {
+		return 0, true
+	}
+	if !list.IsKnown() || !list.CanIterateElements() {
+		return 0, false
+	}
+	return list.LengthInt(), true
 }
 
 func resourceGitopsApplicationsetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/platform/gitops/applicationset/resource_gitops_applicationset_internal_test.go
+++ b/internal/service/platform/gitops/applicationset/resource_gitops_applicationset_internal_test.go
@@ -1,0 +1,49 @@
+package applicationset
+
+import "testing"
+
+func TestCheckExactlyOneSource(t *testing.T) {
+	tests := []struct {
+		name         string
+		sourceCount  int
+		sourcesCount int
+		wantErr      bool
+	}{
+		{
+			name:         "single source only is valid",
+			sourceCount:  1,
+			sourcesCount: 0,
+			wantErr:      false,
+		},
+		{
+			name:         "multiple sources only is valid",
+			sourceCount:  0,
+			sourcesCount: 2,
+			wantErr:      false,
+		},
+		{
+			name:         "neither source nor sources is invalid",
+			sourceCount:  0,
+			sourcesCount: 0,
+			wantErr:      true,
+		},
+		{
+			name:         "both source and sources is invalid",
+			sourceCount:  1,
+			sourcesCount: 2,
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkExactlyOneSource(tt.sourceCount, tt.sourcesCount)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected an error but got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error but got: %v", err)
+			}
+		})
+	}
+}

--- a/internal/service/platform/gitops/applicationset/resource_gitops_applicationset_test.go
+++ b/internal/service/platform/gitops/applicationset/resource_gitops_applicationset_test.go
@@ -1074,7 +1074,6 @@ func testAccResourceGitopsApplicationsetWithSyncPolicy(id, accountId, name, agen
 	`, id, accountId, name, agentId, namespace)
 }
 
-
 func TestAccResourceGitopsApplicationSet_Strategy(t *testing.T) {
 	id := strings.ToLower(fmt.Sprintf("%s%s", t.Name(), utils.RandStringBytes(5)))
 	id = strings.ReplaceAll(id, "_", "")
@@ -1406,5 +1405,147 @@ func testAccResourceGitopsApplicationsetIgnoreApplicationDifferences(id, account
 		  ]
 		}
 	}
+	`, id, accountId, name, agentId, namespace)
+}
+
+func TestAccResourceGitopsApplicationSet_MultiSource(t *testing.T) {
+	id := strings.ToLower(fmt.Sprintf("%s%s", t.Name(), utils.RandStringBytes(5)))
+	id = strings.ReplaceAll(id, "_", "")
+	name := id
+	agentId := os.Getenv("HARNESS_TEST_GITOPS_AGENT_ID")
+	accountId := os.Getenv("HARNESS_ACCOUNT_ID")
+	namespace := os.Getenv("HARNESS_TEST_GITOPS_NAMESPACE")
+	resourceName := "harness_platform_gitops_applicationset.test"
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceGitopsApplicationsetMultiSource(id, accountId, name, agentId, namespace),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "applicationset.0.metadata.0.name", id),
+					resource.TestCheckResourceAttr(resourceName, "applicationset.0.spec.0.template.0.spec.0.sources.0.repo_url", "https://github.com/argoproj/argocd-example-apps.git"),
+					resource.TestCheckResourceAttr(resourceName, "applicationset.0.spec.0.template.0.spec.0.sources.1.ref", "values"),
+					resource.TestCheckResourceAttr(resourceName, "applicationset.0.spec.0.template.0.spec.0.source.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: acctest.GitopsAgentProjectLevelResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccResourceGitopsApplicationsetMultiSource(id, accountId, name, agentId, namespace string) string {
+	return fmt.Sprintf(`
+		resource "harness_platform_organization" "test" {
+			identifier = "%[1]s"
+			name = "%[3]s"
+		}
+
+		resource "harness_platform_project" "test" {
+			identifier = "%[1]s"
+			name = "%[3]s"
+			org_id = harness_platform_organization.test.id
+		}
+
+		resource "harness_platform_gitops_app_project" "test" {
+			account_id = "%[2]s"
+			org_id = harness_platform_organization.test.id
+			project_id = harness_platform_project.test.id
+			agent_id = "%[4]s"
+			upsert = true
+			project {
+				metadata {
+					name = "appset"
+					namespace = "%[5]s"
+				}
+				spec {
+					cluster_resource_whitelist {
+						group = "*"
+						kind = "*"
+					}
+					destinations {
+						namespace = "*"
+						server = "*"
+					}
+					source_repos = ["*"]
+				}
+			}
+			lifecycle {
+				ignore_changes = [
+					project.0.metadata.0.namespace,
+					project.0.metadata.0.finalizers,
+					project.0.metadata.0.labels,
+					project.0.spec.0.source_namespaces,
+				]
+			}
+		}
+
+		resource "harness_platform_gitops_app_project_mapping" "test" {
+			depends_on = [harness_platform_gitops_app_project.test]
+			account_id = "%[2]s"
+			org_id = harness_platform_organization.test.id
+			project_id = harness_platform_project.test.id
+			agent_id = "%[4]s"
+			argo_project_name = harness_platform_gitops_app_project.test.project.0.metadata.0.name
+		}
+
+		resource "harness_platform_gitops_applicationset" "test" {
+			depends_on = [harness_platform_gitops_app_project_mapping.test]
+			applicationset {
+				metadata {
+				  name      = "%[1]s"
+				  namespace = "%[5]s"
+				}
+				spec {
+				  go_template = true
+				  go_template_options = ["missingkey=error"]
+
+				  generator {
+					clusters {
+						enabled = true
+					}
+				  }
+				  template {
+					metadata {
+					  name = "{{.name}}-guestbook"
+					}
+					spec {
+					  project = harness_platform_gitops_app_project.test.project.0.metadata.0.name
+					  sources {
+						repo_url        = "https://github.com/argoproj/argocd-example-apps.git"
+						path            = "helm-guestbook"
+						target_revision = "HEAD"
+					  }
+					  sources {
+						repo_url        = "https://github.com/argoproj/argocd-example-apps.git"
+						target_revision = "HEAD"
+						ref             = "values"
+					  }
+					  destination {
+						server    = "{{.url}}"
+						namespace = "%[5]s"
+					  }
+					}
+				  }
+				}
+			  }
+			project_id = harness_platform_project.test.id
+			org_id = harness_platform_organization.test.id
+		  	agent_id   = "%[4]s"
+		  	upsert     = true
+			lifecycle {
+			  ignore_changes = [
+				applicationset.0.spec.0.generator.0.clusters,
+				applicationset.0.spec.0.template.0.metadata.0.annotations,
+				applicationset.0.spec.0.template.0.metadata.0.labels,
+				applicationset.0.spec.0.template.0.metadata.0.finalizers,
+				applicationset.0.spec.0.template.0.spec.0.project,
+			  ]
+			}
+		}
 	`, id, accountId, name, agentId, namespace)
 }

--- a/internal/service/platform/gitops/schema_application.go
+++ b/internal/service/platform/gitops/schema_application.go
@@ -795,7 +795,7 @@ func ArgoAppSpecSchemaV2(allOptional bool) *schema.Schema {
 				},
 				"sources": {
 					Type:        schema.TypeList,
-					Description: "Location of the application's manifests or chart. Use when specifying multiple fields",
+					Description: "List of sources for the application, used to specify multiple sources for a multi-source application. Mutually exclusive with `source`; specify exactly one of `source` or `sources`.",
 					Optional:    true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
@@ -1020,9 +1020,9 @@ func ArgoAppSpecSchemaV2(allOptional bool) *schema.Schema {
 				},
 				"source": {
 					Type:        schema.TypeList,
-					Description: "Location of the application's manifests or chart.",
-					Optional:    allOptional,
-					Required:    !allOptional,
+					Description: "Location of the application's manifests or chart. Mutually exclusive with `sources`; specify exactly one of `source` or `sources`.",
+					Optional:    true,
+					MaxItems:    1,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"repo_url": {


### PR DESCRIPTION
## Make `source` optional so multi-source (`sources`) templates work

**Summary:**
Fixes a schema bug in `harness_platform_gitops_applicationset` that made the singular `source` block **required** in the Application template spec, preventing users from defining ArgoCD **multi-source** templates with `sources` (plural) alone.

Closes #1387.

**Details:**
Per the [ArgoCD Application spec](https://argo-cd.readthedocs.io/en/stable/user-guide/multiple_sources/), `source` (singular) and `sources` (plural) are mutually exclusive — a template provides exactly one.

In `internal/service/platform/gitops/schema_application.go`, `ArgoAppSpecSchemaV2` declared `sources` as `Optional` but declared `source` as `Optional: allOptional` / `Required: !allOptional`. The ApplicationSet template is built via `resourceApplicationsetTemplate(false)` (`allOptional = false`), so `source` was effectively `Required: true` (`MinItems: 1`). A `sources`-only config therefore failed at plan time with:

```
Error: Insufficient source blocks
At least 1 "source" blocks are required.
```

This PR makes two changes:

1. **Make `source` optional.** `source` is now `Optional: true` (mirroring how `sources` is already declared, and how the single-application schema `ArgoAppSpecSchemaV1` handles both). The inner `repo_url` remains required *when a `source` block is present*, so a provided `source` is still well-formed.

2. **Enforce the ArgoCD contract at plan time.** Simply relaxing `source` to optional would allow a template with *neither* `source` nor `sources` to pass schema validation and then fail later at ArgoCD / the API during `apply`. To keep fast, clear feedback, the resource's existing `CustomizeDiff` now validates the spec-level template (`applicationset.spec.template.spec`) and errors when neither `source` nor `sources` is set ("exactly one is required"), or when both are set ("mutually exclusive"). The check is intentionally scoped to the spec-level template only. Generator-level template overrides (`resourceApplicationsetTemplate(true)`) are partial overrides merged onto the spec-level template and may legitimately omit both, so the rule is not applied there; it targets a single fixed path and needs no traversal of the (recursive) generator templates. `ExactlyOneOf` / `ConflictsWith` are not usable here because `ArgoAppSpecSchemaV2` is shared across many nested/recursive paths, so absolute-path constraints on the shared field would misfire.

No serialization changes are needed: the expand/read logic (`applications.BuildApplicationSpecFromMap` / `BuildAppSpecMap`) already handles `source` and `sources` independently and conditionally. `ArgoAppSpecSchemaV2` is used only by this resource, so the change is scoped to the ApplicationSet.

Descriptions for `source` / `sources` were updated to note they are mutually exclusive, and the singular `source` now has `MaxItems: 1`. Docs were regenerated with `make docs`.

**Related Issues:**
- Closes #1387

**Testing Instructions:**
- `go build ./...`, `go vet ./internal/service/platform/gitops/...` — pass.
- Added unit test `TestCheckExactlyOneSource` covering the exactly-one rule (single source valid, multiple sources valid, neither invalid, both invalid) — runs in `make test` without requiring Harness credentials.
- Added acceptance test `TestAccResourceGitopsApplicationSet_MultiSource` that creates an ApplicationSet whose template uses two `sources` blocks and verifies plan/apply/import succeed.
- `make docs` regenerates docs; `source` now shows as Optional under the ApplicationSet template spec.
- Manual: `terraform apply` a `sources`-only ApplicationSet now succeeds; a repeated apply shows no changes; import works.

Standard resource lifecycle checks:
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes)
- Update the resource and execute terraform apply. (Verify update)
- Remove the resource and execute terraform apply. (Verify deletion)
- Add the resource again and execute terraform apply. (Verify creation)
- Verify import of the resource works.

**Screenshots:**
N/A (schema/validation change).

**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [x] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>

- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
</details>
